### PR TITLE
drop dask and nats as not required anymore

### DIFF
--- a/chart-testing-config.yaml
+++ b/chart-testing-config.yaml
@@ -4,9 +4,7 @@ chart-dirs:
   - charts
 chart-repos:
   - stable=https://charts.helm.sh/stable
-  - dask=https://helm.dask.org/
   - postgres=https://charts.bitnami.com/bitnami
   - yugabyte=https://charts.yugabyte.com
   - windmill=https://windmill-labs.github.io/windmill-helm-charts
-  - nats=https://nats-io.github.io/k8s/helm/charts
 helm-extra-args: --timeout=600s

--- a/charts/godon/Chart.yaml
+++ b/charts/godon/Chart.yaml
@@ -26,10 +26,6 @@ dependencies:
     version: 2.0.311
     repository: https://windmill-labs.github.io/windmill-helm-charts
     alias: windmill
-  - name: dask
-    version: 2024.1.0
-    repository: https://helm.dask.org
-    condition: dask.enabled
   - name: postgresql
     version: 13.2.27
     repository: https://charts.bitnami.com/bitnami
@@ -43,6 +39,3 @@ dependencies:
     repository: https://charts.yugabyte.com
     alias: archive-db
     condition: archive-db.enabled
-  - name: nats
-    version: 1.1.6
-    repository: https://nats-io.github.io/k8s/helm/charts

--- a/charts/godon/osuosl_deploy_values.yml
+++ b/charts/godon/osuosl_deploy_values.yml
@@ -33,7 +33,7 @@ windmill:
         replicas: 1
         extraEnv:
         - name: WHITELIST_ENVS
-          value: "GODON_DASK_SCHEDULER_SERVICE_PORT,GODON_LOCKING_DB_SERVICE_PORT,GODON_API_SERVICE_PORT,GODON_METADATA_DB_SERVICE_PORT,YB_TSERVER_SERVICE_SERVICE_PORT,GODON_DASK_SCHEDULER_SERVICE_HOST,GODON_LOCKING_DB_SERVICE_HOST,GODON_API_SERVICE_HOST,GODON_METADATA_DB_SERVICE_HOST,YB_TSERVER_SERVICE_SERVICE_HOST,YB_TSERVER_SERVICE_SERVICE_PORT_TCP_YSQL_PORT"
+          value: "GODON_LOCKING_DB_SERVICE_PORT,GODON_API_SERVICE_PORT,GODON_METADATA_DB_SERVICE_PORT,YB_TSERVER_SERVICE_SERVICE_PORT,GODON_LOCKING_DB_SERVICE_HOST,GODON_API_SERVICE_HOST,GODON_METADATA_DB_SERVICE_HOST,YB_TSERVER_SERVICE_SERVICE_HOST,YB_TSERVER_SERVICE_SERVICE_PORT_TCP_YSQL_PORT"
 
 ########################################
 ## Component | Godon Metrics Exporter
@@ -93,36 +93,6 @@ api:
 
   volumeMounts: []
 
-########################################
-## Component | Dask Cluster for Distributed Metaheuristics Processing
-########################################
-dask:
-  enabled: true
-
-  ## The Dask entrypoint is the scheduler
-  scheduler:
-    name: Optuna-Dask-Scheduler
-    enabled: true
-    image:
-      repository: "ghcr.io/godon-dev/godon-dask"
-      tag: "0.0.1"
-      pullPolicy: IfNotPresent
-    servicePort: 8786
-
-  ## The Dask Workers
-  worker:
-    name: Optuna-Dask-Worker
-    image:
-      repository: "ghcr.io/godon-dev/godon-dask"
-      tag: "0.0.1"
-      pullPolicy: IfNotPresent
-    replicas: 2
-
-  ## Jupyter not needed
-  jupyter:
-    enabled: false
-
-########################################
 ## Component | Postgres Based Distributed Locking Database
 ########################################
 locking-db:
@@ -204,26 +174,3 @@ archive-db:
 
   dnsPolicy: ClusterFirst
 
-########################################
-## CONFIG | Nats Queueing System
-########################################
-nats:
-  podDisruptionBudget:
-    enable: false
-  service:
-    enabled: true
-  natsBox:
-    enabled: false
-  container:
-    image:
-      repository: nats
-      tag: 2.9.15
-  nats:
-    port: 4222
-    tls:
-      enabled: false
-  monitor:
-    enabled: false
-    port: 8222
-    tls:
-      enabled: false

--- a/charts/godon/templates/config.yml
+++ b/charts/godon/templates/config.yml
@@ -7,14 +7,3 @@ metadata:
     heritage: {{ .Release.Service }}
 ## we must use `data` rather than `stringData` (see: https://github.com/helm/helm/issues/10010)
 data:
-  ## ================
-  ## Service Interaction Configs
-  ## ================
-  ## queuing system service host/port
-  SVC_NATS_HOST: {{ printf "%s-nats.%s.svc.%s" (include "godon.fullname" .) (.Release.Namespace) (.Values.clusterDomain) | b64enc | quote }}
-  SVC_NATS_PORT: {{ "14222" | b64enc | quote }}
-
-  ## processing parallelization service host/port
-  SVC_DASK_PROTOCOL: {{ "tcp" | b64enc | quote }}
-  SVC_DASK_HOST: {{ printf "%s-dask.%s.svc.%s" (include "godon.fullname" .) (.Release.Namespace) (.Values.clusterDomain) | b64enc | quote }}
-  SVC_DASK_PORT: {{ "8786" | b64enc | quote }}

--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -90,32 +90,6 @@ api:
 
   volumeMounts: []
 
-########################################
-## Component | Dask Cluster for Distributed Metaheuristics Processing
-########################################
-dask:
-  enabled: true
-
-  ## The Dask entrypoint is the scheduler
-  scheduler:
-    name: Optuna-Dask-Scheduler
-    enabled: true
-    image:
-      repository: "ghcr.io/dask/dask"
-      tag: "2023.12.1"
-      pullPolicy: IfNotPresent
-    servicePort: 8786
-
-  ## The Dask Workers
-  worker:
-    name: Optuna-Dask-Worker
-    image:
-      repository: "ghcr.io/dask/dask"
-      tag: "2023.12.1"
-      pullPolicy: IfNotPresent
-    replicas: 3
-
-########################################
 ## Component | Postgres Based Distributed Locking Database
 ########################################
 locking-db:
@@ -197,20 +171,3 @@ archive-db:
 
   dnsPolicy: ClusterFirst
 
-########################################
-## CONFIG | Nats Queueing System
-########################################
-nats:
-  container:
-    image:
-      repository: nats
-      tag: 2.9.15
-  nats:
-    port: 4222
-    tls:
-      enabled: false
-  monitor:
-    enabled: true
-    port: 8222
-    tls:
-      enabled: false


### PR DESCRIPTION
From breeder rework - windmill drives the optuna trials fully by now. Hence not nats from communication between optuna running on dask necessary anymore.