### PR TITLE
fix: resolve KIND kubeconfig - chart workflows

### DIFF
--- a/.github/workflows/charts--reinstall-stack.yaml
+++ b/.github/workflows/charts--reinstall-stack.yaml
@@ -12,36 +12,61 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify KIND Cluster
+        run: |
+          echo "🔍 Verifying KIND cluster..."
+          
+          # Check if KIND cluster exists
+          if ! kind get clusters | grep -q "godon-1-cluster"; then
+            echo "❌ KIND cluster 'godon-1-cluster' not found"
+            echo "Available clusters:"
+            kind get clusters
+            echo ""
+            echo "Please run the 'kind--setup-cluster' workflow first"
+            exit 1
+          fi
+          
+          echo "✅ KIND cluster exists"
+          
+          # Export kubeconfig to known location
+          kind export kubeconfig --name=godon-1-cluster --kubeconfig=/tmp/kind_kubeconfig.yaml
+          
+          # Verify connectivity
+          kubectl cluster-info --kubeconfig=/tmp/kind_kubeconfig.yaml
+
       - name: Cleanup Former Deployment
+        env:
+          KUBECONFIG: /tmp/kind_kubeconfig.yaml
         run: |
           echo "🧹 Cleaning up former Godon deployment (including databases)"
           helm uninstall godon \
-               --kubeconfig /run/kind_kubeconfig.yaml \
                --wait --ignore-not-found \
                --namespace godon
 
       - name: Deploy Fresh Godon Stack
+        env:
+          KUBECONFIG: /tmp/kind_kubeconfig.yaml
         run: |
           echo "🚀 Deploying fresh Godon stack (clean state)"
           helm install godon ./charts/godon/ \
-               --kubeconfig /run/kind_kubeconfig.yaml \
                --dependency-update \
                --create-namespace --namespace godon \
                --values ./charts/godon/osuosl_deploy_values.yml \
                --wait --timeout 20m
 
       - name: Deployment Status Report
+        env:
+          KUBECONFIG: /tmp/kind_kubeconfig.yaml
         run: |
           echo "📊 Fresh Godon Stack Status"
           echo "=============================="
           helm status godon \
-               --kubeconfig /run/kind_kubeconfig.yaml \
                --namespace godon \
                --show-resources
 
           echo ""
           echo "🏥 Pod Status"
-          kubectl get pods -n godon --kubeconfig /run/kind_kubeconfig.yaml
+          kubectl get pods -n godon
 
           echo ""
           echo "✅ Clean slate deployment complete"

--- a/.github/workflows/charts--stack-status.yaml
+++ b/.github/workflows/charts--stack-status.yaml
@@ -17,7 +17,31 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify KIND Cluster
+        run: |
+          echo "🔍 Verifying KIND cluster..."
+          
+          # Check if KIND cluster exists
+          if ! kind get clusters | grep -q "godon-1-cluster"; then
+            echo "❌ KIND cluster 'godon-1-cluster' not found"
+            echo "Available clusters:"
+            kind get clusters
+            echo ""
+            echo "Please run the 'kind--setup-cluster' workflow first"
+            exit 1
+          fi
+          
+          echo "✅ KIND cluster exists"
+          
+          # Export kubeconfig to known location
+          kind export kubeconfig --name=godon-1-cluster --kubeconfig=/tmp/kind_kubeconfig.yaml
+          
+          # Verify connectivity
+          kubectl cluster-info --kubeconfig=/tmp/kind_kubeconfig.yaml
+
       - name: Overall Stack Status
+        env:
+          KUBECONFIG: /tmp/kind_kubeconfig.yaml
         run: |
           echo "🔍 Godon Stack Status Analysis"
           echo "==============================="
@@ -26,38 +50,37 @@ jobs:
           # Helm release status
           echo "📊 Helm Release Status"
           helm status godon \
-               --kubeconfig /run/kind_kubeconfig.yaml \
                --namespace godon \
                --show-resources || echo "⚠️  No Helm release found"
           
           echo ""
           echo "🏥 Pod Status"
-          kubectl get pods -n godon --kubeconfig /run/kind_kubeconfig.yaml \
-            -o wide
+          kubectl get pods -n godon -o wide
           
           echo ""
           echo "🌐 Service Status"
-          kubectl get services -n godon --kubeconfig /run/kind_kubeconfig.yaml
+          kubectl get services -n godon
           
           echo ""
           echo "📦 Deployments"
-          kubectl get deployments -n godon --kubeconfig /run/kind_kubeconfig.yaml
+          kubectl get deployments -n godon
           
           echo ""
           echo "💾 Persistent Volumes"
-          kubectl get pvc -n godon --kubeconfig /run/kind_kubeconfig.yaml
+          kubectl get pvc -n godon
           
           echo ""
           echo "🎯 Recent Events"
-          kubectl get events -n godon --kubeconfig /run/kind_kubeconfig.yaml \
+          kubectl get events -n godon \
             --sort-by='.lastTimestamp' | tail -20
 
       - name: Component Deep Dive
         if: inputs.component != ''
+        env:
+          KUBECONFIG: /tmp/kind_kubeconfig.yaml
         run: |
           set -eEux
           component="${{ inputs.component }}"
-          kubeconfig="/run/kind_kubeconfig.yaml"
           namespace="godon"
           
           echo "🔬 Deep Dive: ${component}"
@@ -65,7 +88,7 @@ jobs:
           echo ""
           
           # Find matching pods
-          pods=$(kubectl get pods -n "${namespace}" --kubeconfig "${kubeconfig}" \
+          pods=$(kubectl get pods -n "${namespace}" \
             -o json | jq -r ".items[] | select(.metadata.name | contains(\"${component}\")) | .metadata.name")
           
           for pod in ${pods}; do
@@ -73,21 +96,23 @@ jobs:
             echo "-------------------"
             
             # Pod details
-            kubectl get pod "${pod}" -n "${namespace}" --kubeconfig "${kubeconfig}" -o json
+            kubectl get pod "${pod}" -n "${namespace}" -o json
             
             echo ""
             echo "📋 Recent Logs (last 50 lines)"
-            kubectl logs "${pod}" -n "${namespace}" --kubeconfig "${kubeconfig}" --tail=50 \
+            kubectl logs "${pod}" -n "${namespace}" --tail=50 \
               || echo "No logs available"
             
             echo ""
             echo "🔧 Pod Description"
-            kubectl describe pod "${pod}" -n "${namespace}" --kubeconfig "${kubeconfig}"
+            kubectl describe pod "${pod}" -n "${namespace}"
             
             echo ""
           done
 
       - name: Database Health Check
+        env:
+          KUBECONFIG: /tmp/kind_kubeconfig.yaml
         run: |
           echo "💾 Database Status"
           echo "=================="
@@ -95,20 +120,20 @@ jobs:
           
           # Check YugaByte
           echo "🐘 YugaByteDB Status"
-          kubectl get pods -n godon --kubeconfig /run/kind_kubeconfig.yaml \
-            -l app=yugabytedb -o wide
+          kubectl get pods -n godon -l app=yugabytedb -o wide
           
           # Check Windmill DB  
           echo "🌊 Windmill Database Status"
-          kubectl get pods -n godon --kubeconfig /run/kind_kubeconfig.yaml \
-            -l app=windmill -o wide
+          kubectl get pods -n godon -l app=windmill -o wide
           
           echo ""
           echo "💾 PVC Status"
-          kubectl get pvc -n godon --kubeconfig /run/kind_kubeconfig.yaml \
+          kubectl get pvc -n godon \
             -o custom-columns=NAME:.metadata.name,STATUS:.status.phase,CAPACITY:.status.capacity.storage
 
       - name: Network Connectivity Check
+        env:
+          KUBECONFIG: /tmp/kind_kubeconfig.yaml
         run: |
           echo "🌐 Network Connectivity"
           echo "======================="
@@ -116,20 +141,22 @@ jobs:
           
           # Check endpoints
           echo "🔗 Service Endpoints"
-          kubectl get endpoints -n godon --kubeconfig /run/kind_kubeconfig.yaml
+          kubectl get endpoints -n godon
           
           echo ""
           echo "🌍 Ingress/Routes"
-          kubectl get ingress -n godon --kubeconfig /run/kind_kubeconfig.yaml \
+          kubectl get ingress -n godon \
             || echo "No ingress resources"
           
           echo ""
           echo "🔌 Network Policies"
-          kubectl get networkpolicy -n godon --kubeconfig /run/kind_kubeconfig.yaml \
+          kubectl get networkpolicy -n godon \
             || echo "No network policies"
 
       - name: Error Summary
         if: always()
+        env:
+          KUBECONFIG: /tmp/kind_kubeconfig.yaml
         run: |
           echo "🚨 Error Summary"
           echo "================"
@@ -137,18 +164,18 @@ jobs:
           
           # Find non-running pods
           echo "❌ Problem Pods:"
-          kubectl get pods -n godon --kubeconfig /run/kind_kubeconfig.yaml \
+          kubectl get pods -n godon \
             -o json | jq -r '.items[] | select(.status.phase != "Running") | "\(.metadata.name): \(.status.phase)"' \
             || echo "All pods are running"
           
           echo ""
           echo "⚠️  Pods with Restarts:"
-          kubectl get pods -n godon --kubeconfig /run/kind_kubeconfig.yaml \
+          kubectl get pods -n godon \
             -o json | jq -r '.items[] | select(.status.containerStatuses[0].restartCount > 0) | "\(.metadata.name): \(.status.containerStatuses[0].restartCount) restarts"' \
             || echo "No restarts"
           
           echo ""
           echo "📋 Failed Jobs/CronJobs:"
-          kubectl get jobs -n godon --kubeconfig /run/kind_kubeconfig.yaml \
+          kubectl get jobs -n godon \
             -o json | jq -r '.items[] | select(.status.failed > 0) | "\(.metadata.name): \(.status.failed) failures"' \
             || echo "No failed jobs"

--- a/.github/workflows/charts--upgrade-stack.yaml
+++ b/.github/workflows/charts--upgrade-stack.yaml
@@ -12,26 +12,50 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify KIND Cluster
+        run: |
+          echo "🔍 Verifying KIND cluster..."
+          
+          # Check if KIND cluster exists
+          if ! kind get clusters | grep -q "godon-1-cluster"; then
+            echo "❌ KIND cluster 'godon-1-cluster' not found"
+            echo "Available clusters:"
+            kind get clusters
+            echo ""
+            echo "Please run the 'kind--setup-cluster' workflow first"
+            exit 1
+          fi
+          
+          echo "✅ KIND cluster exists"
+          
+          # Export kubeconfig to known location
+          kind export kubeconfig --name=godon-1-cluster --kubeconfig=/tmp/kind_kubeconfig.yaml
+          
+          # Verify connectivity
+          kubectl cluster-info --kubeconfig=/tmp/kind_kubeconfig.yaml
+
       - name: Upgrade Godon Stack
+        env:
+          KUBECONFIG: /tmp/kind_kubeconfig.yaml
         run: |
           echo "🔄 Upgrading Godon stack (preserving databases and state)"
           helm upgrade godon ./charts/godon/ \
-               --kubeconfig /run/kind_kubeconfig.yaml \
                --dependency-update \
                --create-namespace --namespace godon \
                --values ./charts/godon/osuosl_deploy_values.yml \
                --wait --timeout 15m
 
       - name: Deployment Status Report
+        env:
+          KUBECONFIG: /tmp/kind_kubeconfig.yaml
         run: |
           echo "📊 Godon Stack Status After Upgrade"
           echo "========================================"
           helm status godon \
-               --kubeconfig /run/kind_kubeconfig.yaml \
                --namespace godon \
                --show-resources
 
           echo ""
           echo "🏥 Pod Status"
-          kubectl get pods -n godon --kubeconfig /run/kind_kubeconfig.yaml
+          kubectl get pods -n godon
 

--- a/.github/workflows/kind--setup-cluster.yaml
+++ b/.github/workflows/kind--setup-cluster.yaml
@@ -14,4 +14,13 @@ jobs:
 
       - name: Setup kind cluster config
         run: |
-          kind create cluster --config /github-runner/godon-charts/godon-charts/kind_config.yaml --kubeconfig /run/kind_kubeconfig.yaml --wait 10m
+          echo "🔧 Creating KIND cluster..."
+          kind create cluster \
+            --config ./kind_config.yaml \
+            --name godon-1-cluster \
+            --kubeconfig /tmp/kind_kubeconfig.yaml \
+            --wait 10m
+          
+          echo "✅ KIND cluster created successfully"
+          kind get clusters
+          kubectl cluster-info --kubeconfig=/tmp/kind_kubeconfig.yaml


### PR DESCRIPTION
  - Fix incorrect kubeconfig path references (use /tmp/kind_kubeconfig.yaml)
  - Add KIND cluster verification step to all deployment workflows
  - Use KUBECONFIG environment variable instead of hardcoded paths
  - Improve kind--setup-cluster workflow with better error handling
  - Maintain separation of concerns between cluster and deployment management

  Fixes workflow failures where kubectl/helm couldn't access KIND cluster
  due to missing /run/kind_kubeconfig.yaml path.