### PR TITLE
fix: KIND kubeconfig issues in chart workflows

### DIFF
--- a/.github/workflows/kind--delete-cluster.yaml
+++ b/.github/workflows/kind--delete-cluster.yaml
@@ -1,0 +1,40 @@
+name: "Delete Kubernetes KIND Cluster"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  delete_cluster:
+    runs-on: [self-hosted, linux]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Delete KIND Cluster
+        run: |
+          echo "🗑️  Deleting KIND cluster..."
+          
+          if ! kind get clusters | grep -q "godon-1-cluster"; then
+            echo "⚠️  KIND cluster 'godon-1-cluster' does not exist"
+            echo "Available clusters:"
+            kind get clusters
+            exit 0
+          fi
+          
+          echo "🔍 Current clusters:"
+          kind get clusters
+          
+          echo "🗑️  Deleting cluster 'godon-1-cluster'..."
+          kind delete cluster --name godon-1-cluster
+          
+          echo "✅ KIND cluster deleted successfully"
+          echo "🔍 Remaining clusters:"
+          kind get clusters || echo "No clusters remaining"
+
+      - name: Cleanup Artifacts
+        run: |
+          echo "🧹 Cleaning up kubeconfig and artifacts..."
+          rm -f /tmp/kind_kubeconfig.yaml
+          echo "✅ Cleanup complete"

--- a/.github/workflows/kind--setup-cluster.yaml
+++ b/.github/workflows/kind--setup-cluster.yaml
@@ -15,6 +15,14 @@ jobs:
       - name: Setup kind cluster config
         run: |
           echo "🔧 Creating KIND cluster..."
+          
+          if kind get clusters | grep -q "godon-1-cluster"; then
+            echo "❌ KIND cluster 'godon-1-cluster' already exists"
+            echo "Please delete it first:"
+            echo "  kind delete cluster --name godon-1-cluster"
+            exit 1
+          fi
+          
           kind create cluster \
             --config ./kind_config.yaml \
             --name godon-1-cluster \


### PR DESCRIPTION
  - Fix incorrect kubeconfig path references (use /tmp/kind_kubeconfig.yaml)
  - Add KIND cluster verification step to all deployment workflows
  - Use KUBECONFIG environment variable instead of hardcoded paths
  - Improve kind--setup-cluster workflow with better error handling
  - Add kind--delete-cluster workflow for proper cluster disposal
  - Maintain separation of concerns between cluster and deployment management

  Fixes workflow failures where kubectl/helm couldn't access KIND cluster
  due to missing /run/kind_kubeconfig.yaml path.