### PR TITLE
fix: upstream network.yml for breeder smoke test

### DIFF
--- a/.github/workflows/charts--smoke-tests.yaml
+++ b/.github/workflows/charts--smoke-tests.yaml
@@ -456,10 +456,7 @@ jobs:
           name: "smoke-test-ssh-key"
           credentialType: "ssh_private_key"
           description: "SSH key for smoke testing"
-          content: |
-            -----BEGIN RSA PRIVATE KEY-----
-            MIIEpAIBAAKCAQEA2Z2H7V...
-            -----END RSA PRIVATE KEY-----
+          content: "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA2Z2H7V...\n-----END RSA PRIVATE KEY-----"
           EOF
 
           chmod 644 credential-test-config.yaml

--- a/.github/workflows/charts--smoke-tests.yaml
+++ b/.github/workflows/charts--smoke-tests.yaml
@@ -237,7 +237,7 @@ jobs:
           echo "File exists in workflow: $(ls -la network-upstream.yml)"
 
           CREATE_OUTPUT=$(docker run --rm --network host \
-            -v $(pwd):/work:ro \
+            -v $(pwd):/work \
             -w /work \
             -e SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt \
             -e NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt \
@@ -333,61 +333,99 @@ jobs:
           CLI_CONTAINER_IMAGE="ghcr.io/godon-dev/godon-cli:latest"
           API_HOST="${{ env.API_HOST }}"
           API_PORT="${{ env.API_PORT }}"
-          
-          # Test 1: Invalid UUID format
-          echo "❌ BREEDER SHOW - Invalid UUID format:"
-          docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \
-            --hostname=${API_HOST} --port=${API_PORT} --insecure breeder show --id="invalid-uuid-format" || echo "✅ Invalid UUID properly rejected"
-          
-          # Test 2: Non-existent breeder
-          echo "❌ BREEDER SHOW - Non-existent breeder:"
-          docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \
-            --hostname=${API_HOST} --port=${API_PORT} --insecure breeder show --id="00000000-0000-4000-8000-000000000000" || echo "✅ Non-existent breeder properly handled"
 
-          # Test 3: Delete non-existent breeder
-          echo "❌ BREEDER PURGE - Non-existent breeder:"
-          docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \
-            --hostname=${API_HOST} --port=${API_PORT} --insecure breeder purge --id="99999999-9999-4999-9999-999999999999" || echo "✅ Non-existent breeder deletion properly handled"
-          
-          # Test 4: Malformed breeder config
-          echo "❌ BREEDER CREATE - Malformed config:"
-          cat > /tmp/malformed-breeder-config.yaml << 'EOF'
+          # Create all test config files first
+          echo "Creating test config files..."
+          cat > malformed-breeder-config.yaml << 'EOF'
           malformed: yaml content
           invalid:
           EOF
 
-          docker run --rm --network host \
-            -v /tmp/malformed-breeder-config.yaml:/malformed-config.yaml:ro \
+          cat > special-chars-breeder-config.yaml << 'EOF'
+          meta:
+            configVersion: "0.2"
+          settings:
+            test: value
+          EOF
+
+          cat > unicode-breeder-config.yaml << 'EOF'
+          meta:
+            configVersion: "0.2"
+          settings:
+            test: value
+          EOF
+
+          # Fix permissions to ensure container can read them
+          chmod 644 *.yaml
+
+          echo "✅ Test files created"
+          echo "📝 DEBUG: Listing created files:"
+          ls -la *.yaml
+          echo "📝 DEBUG: Current directory: $(pwd)"
+
+          # Test 1: Invalid UUID format
+          echo "🧪 TEST: BREEDER SHOW with invalid UUID format (should reject):"
+          if docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \
+            --hostname=${API_HOST} --port=${API_PORT} --insecure breeder show --id="invalid-uuid-format" 2>&1; then
+            echo "❌ FAIL: Should have rejected invalid UUID format"
+          else
+            echo "✅ PASS: Invalid UUID format properly rejected"
+          fi
+
+          # Test 2: Non-existent breeder
+          echo "🧪 TEST: BREEDER SHOW with non-existent UUID (should return error):"
+          if docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \
+            --hostname=${API_HOST} --port=${API_PORT} --insecure breeder show --id="00000000-0000-4000-8000-000000000000" 2>&1; then
+            echo "❌ FAIL: Should have returned error for non-existent breeder"
+          else
+            echo "✅ PASS: Non-existent breeder properly handled"
+          fi
+
+          # Test 3: Delete non-existent breeder
+          echo "🧪 TEST: BREEDER PURGE with non-existent UUID (should return error):"
+          if docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \
+            --hostname=${API_HOST} --port=${API_PORT} --insecure breeder purge --id="99999999-9999-4999-9999-999999999999" 2>&1; then
+            echo "❌ FAIL: Should have returned error for non-existent breeder"
+          else
+            echo "✅ PASS: Non-existent breeder deletion properly handled"
+          fi
+
+          # Test 4: Malformed breeder config
+          echo "🧪 TEST: BREEDER CREATE with malformed config (should reject):"
+          echo "📝 DEBUG: Mounting $(pwd) to /work"
+          if docker run --rm --network host \
+            -v $(pwd):/work \
+            -w /work \
             "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-            breeder create --name="malformed" --file=/malformed-config.yaml || echo "✅ Malformed config properly rejected"
+            breeder create --name="malformed" --file=malformed-breeder-config.yaml 2>&1; then
+            echo "❌ FAIL: Should have rejected malformed config"
+          else
+            echo "✅ PASS: Malformed config properly rejected"
+          fi
           
           # Test 5: Breeder name with special characters
-          echo "🔍 BREEDER CREATE - Special characters in name:"
-          cat > /tmp/special-chars-breeder-config.yaml << 'EOF'
-          meta:
-            configVersion: "0.2"
-          settings:
-            test: value
-          EOF
-
-          docker run --rm --network host \
-            -v /tmp/special-chars-breeder-config.yaml:/special-chars-config.yaml:ro \
+          echo "🧪 TEST: BREEDER CREATE with special characters in name:"
+          if docker run --rm --network host \
+            -v $(pwd):/work \
+            -w /work \
             "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-            breeder create --name="test-breeder-with-special-chars" --file=/special-chars-config.yaml || echo "✅ Special characters handled or rejected"
-          
+            breeder create --name="test-breeder-with-special-chars" --file=special-chars-breeder-config.yaml 2>&1; then
+            echo "✅ PASS: Special characters accepted"
+          else
+            echo "✅ PASS: Special characters handled or rejected (both acceptable)"
+          fi
+
           # Test 6: Unicode breeder name
-          echo "🔍 BREEDER CREATE - Unicode characters in name:"
-          cat > /tmp/unicode-breeder-config.yaml << 'EOF'
-          meta:
-            configVersion: "0.2"
-          settings:
-            test: value
-          EOF
-
-          docker run --rm --network host \
-            -v /tmp/unicode-breeder-config.yaml:/unicode-config.yaml:ro \
+          echo "🧪 TEST: BREEDER CREATE with unicode characters in name:"
+          if docker run --rm --network host \
+            -v $(pwd):/work \
+            -w /work \
             "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-            breeder create --name="test-breeder-unicode-🚀-测试" --file=/unicode-config.yaml || echo "✅ Unicode characters handled or rejected"
+            breeder create --name="test-breeder-unicode-🚀-测试" --file=unicode-breeder-config.yaml 2>&1; then
+            echo "✅ PASS: Unicode characters accepted"
+          else
+            echo "✅ PASS: Unicode characters handled or rejected (both acceptable)"
+          fi
           
           # Test 7: Empty breeder list scenario
           echo "📋 BREEDER LIST - Verify empty list handling:"
@@ -414,9 +452,9 @@ jobs:
           echo "🔨 CREDENTIAL CREATE - Creating test credential:"
 
           # Create test credential config
-          cat > /tmp/credential-test-config.yaml << 'EOF'
+          cat > credential-test-config.yaml << 'EOF'
           name: "smoke-test-ssh-key"
-          credential_type: "ssh_private_key"
+          credentialType: "ssh_private_key"
           description: "SSH key for smoke testing"
           content: |
             -----BEGIN RSA PRIVATE KEY-----
@@ -424,10 +462,13 @@ jobs:
             -----END RSA PRIVATE KEY-----
           EOF
 
+          chmod 644 credential-test-config.yaml
+
           CREATE_OUTPUT=$(docker run --rm --network host \
-            -v /tmp/credential-test-config.yaml:/credential-config.yaml:ro \
+            -v $(pwd):/work:ro \
+            -w /work \
             "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-            credential create --file=/credential-config.yaml --output=json 2>&1)
+            credential create --file=credential-test-config.yaml --output=json 2>&1)
           
           echo "${CREATE_OUTPUT}"
           
@@ -472,80 +513,122 @@ jobs:
           CLI_CONTAINER_IMAGE="ghcr.io/godon-dev/godon-cli:latest"
           API_HOST="${{ env.API_HOST }}"
           API_PORT="${{ env.API_PORT }}"
-          
-          # Test 1: Invalid UUID format
-          echo "❌ CREDENTIAL SHOW - Invalid UUID format:"
-          docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \
-            --hostname=${API_HOST} --port=${API_PORT} --insecure credential show --id="invalid-uuid-format" || echo "✅ Invalid UUID properly rejected"
-          
-          # Test 2: Non-existent credential
-          echo "❌ CREDENTIAL SHOW - Non-existent credential:"
-          docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \
-            --hostname=${API_HOST} --port=${API_PORT} --insecure credential show --id="00000000-0000-4000-8000-000000000000" || echo "✅ Non-existent credential properly handled"
 
-          # Test 3: Delete non-existent credential
-          echo "❌ CREDENTIAL DELETE - Non-existent credential:"
-          docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \
-            --hostname=${API_HOST} --port=${API_PORT} --insecure credential delete --id="99999999-9999-4999-9999-999999999999" || echo "✅ Non-existent credential deletion properly handled"
-          
-          # Test 4: Malformed credential config
-          echo "❌ CREDENTIAL CREATE - Malformed config:"
-          cat > /tmp/malformed-credential-config.yaml << 'EOF'
+          # Create all test config files first
+          echo "Creating test config files..."
+          cat > malformed-credential-config.yaml << 'EOF'
           name: ""
           credentialType: "invalid_type"
           content: ""
           EOF
-          
-          docker run --rm --network host \
-            -v /tmp/malformed-credential-config.yaml:/malformed-cred-config.yaml:ro \
-            "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-            credential create --file=/malformed-cred-config.yaml || echo "✅ Malformed config properly rejected"
-          
-          # Test 5: Invalid credential type
-          echo "❌ CREDENTIAL CREATE - Invalid credential type:"
-          cat > /tmp/invalid-type-credential-config.yaml << 'EOF'
+
+          cat > invalid-type-credential-config.yaml << 'EOF'
           name: "test-invalid-type"
           credentialType: "non_existent_type"
           description: "Testing invalid credential type"
           content: "test content"
           EOF
-          
-          docker run --rm --network host \
-            -v /tmp/invalid-type-credential-config.yaml:/invalid-type-config.yaml:ro \
-            "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-            credential create --file=/invalid-type-config.yaml || echo "✅ Invalid credential type properly rejected"
-          
-          # Test 6: Empty credential content
-          echo "❌ CREDENTIAL CREATE - Empty content:"
-          cat > /tmp/empty-content-credential-config.yaml << 'EOF'
+
+          cat > empty-content-credential-config.yaml << 'EOF'
           name: "test-empty-content"
           credentialType: "ssh_private_key"
           description: "Testing empty content"
           content: ""
           EOF
-          
-          docker run --rm --network host \
-            -v /tmp/empty-content-credential-config.yaml:/empty-content-config.yaml:ro \
-            "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-            credential create --file=/empty-content-config.yaml || echo "✅ Empty content properly rejected"
-          
-          # Test 7: Credential name with special characters
-          echo "🔍 CREDENTIAL CREATE - Special characters in name:"
-          cat > /tmp/special-chars-credential-config.yaml << 'EOF'
+
+          cat > special-chars-credential-config.yaml << 'EOF'
           name: "test-cred-with-special-chars-<>-\"-\\-"
           credentialType: "ssh_private_key"
           description: "Testing special character handling"
           content: >
             -----BEGIN RSA PRIVATE KEY-----
             MIIEpAIBAAKCAQEA2Z9Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2
-            2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2
+            2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2
             -----END RSA PRIVATE KEY-----
           EOF
-          
-          docker run --rm --network host \
-            -v /tmp/special-chars-credential-config.yaml:/special-chars-cred-config.yaml:ro \
+
+          # Fix permissions to ensure container can read them
+          chmod 644 *.yaml
+
+          echo "✅ Test files created"
+          echo "📝 DEBUG: Listing created files:"
+          ls -la *.yaml
+          echo "📝 DEBUG: Current directory: $(pwd)"
+
+          # Test 1: Invalid UUID format
+          echo "🧪 TEST: CREDENTIAL SHOW with invalid UUID format (should reject):"
+          if docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \
+            --hostname=${API_HOST} --port=${API_PORT} --insecure credential show --id="invalid-uuid-format" 2>&1; then
+            echo "❌ FAIL: Should have rejected invalid UUID format"
+          else
+            echo "✅ PASS: Invalid UUID format properly rejected"
+          fi
+
+          # Test 2: Non-existent credential
+          echo "🧪 TEST: CREDENTIAL SHOW with non-existent UUID (should return error):"
+          if docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \
+            --hostname=${API_HOST} --port=${API_PORT} --insecure credential show --id="00000000-0000-4000-8000-000000000000" 2>&1; then
+            echo "❌ FAIL: Should have returned error for non-existent credential"
+          else
+            echo "✅ PASS: Non-existent credential properly handled"
+          fi
+
+          # Test 3: Delete non-existent credential
+          echo "🧪 TEST: CREDENTIAL DELETE with non-existent UUID (should return error):"
+          if docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \
+            --hostname=${API_HOST} --port=${API_PORT} --insecure credential delete --id="99999999-9999-4999-9999-999999999999" 2>&1; then
+            echo "❌ FAIL: Should have returned error for non-existent credential"
+          else
+            echo "✅ PASS: Non-existent credential deletion properly handled"
+          fi
+
+          # Test 4: Malformed credential config
+          echo "🧪 TEST: CREDENTIAL CREATE with malformed config (should reject):"
+          if docker run --rm --network host \
+            -v $(pwd):/work \
+            -w /work \
             "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-            credential create --file=/special-chars-cred-config.yaml || echo "✅ Special characters handled or rejected"
+            credential create --file=malformed-credential-config.yaml 2>&1; then
+            echo "❌ FAIL: Should have rejected malformed config"
+          else
+            echo "✅ PASS: Malformed config properly rejected"
+          fi
+
+          # Test 5: Invalid credential type
+          echo "🧪 TEST: CREDENTIAL CREATE with invalid credential type (should reject):"
+          if docker run --rm --network host \
+            -v $(pwd):/work \
+            -w /work \
+            "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
+            credential create --file=invalid-type-credential-config.yaml 2>&1; then
+            echo "❌ FAIL: Should have rejected invalid credential type"
+          else
+            echo "✅ PASS: Invalid credential type properly rejected"
+          fi
+
+          # Test 6: Empty credential content
+          echo "🧪 TEST: CREDENTIAL CREATE with empty content (should reject):"
+          if docker run --rm --network host \
+            -v $(pwd):/work \
+            -w /work \
+            "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
+            credential create --file=empty-content-credential-config.yaml 2>&1; then
+            echo "❌ FAIL: Should have rejected empty content"
+          else
+            echo "✅ PASS: Empty content properly rejected"
+          fi
+
+          # Test 7: Credential name with special characters
+          echo "🧪 TEST: CREDENTIAL CREATE with special characters in name:"
+          if docker run --rm --network host \
+            -v $(pwd):/work \
+            -w /work \
+            "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
+            credential create --file=special-chars-credential-config.yaml 2>&1; then
+            echo "✅ PASS: Special characters accepted"
+          else
+            echo "✅ PASS: Special characters handled or rejected (both acceptable)"
+          fi
           
           # Test 8: Empty credential list scenario
           echo "📋 CREDENTIAL LIST - Verify empty list handling:"
@@ -566,7 +649,7 @@ jobs:
           # Create multiple breeders in succession
           echo "🔨 Creating multiple breeders..."
           for i in {1..5}; do
-            cat > /tmp/breeder-stress-config-${i}.yaml << EOF
+            cat > breeder-stress-config-${i}.yaml << EOF
           meta:
             configVersion: "0.2"
           settings:
@@ -575,9 +658,10 @@ jobs:
           EOF
 
             docker run --rm --network host \
-              -v /tmp/breeder-stress-config-${i}.yaml:/breeder-config.yaml:ro \
+              -v $(pwd):/work \
+              -w /work \
               "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-              breeder create --name="stress-test-breeder-${i}" --file=/breeder-config.yaml || echo "⚠️  Breeder ${i} creation failed"
+              breeder create --name="stress-test-breeder-${i}" --file=breeder-stress-config-${i}.yaml || echo "⚠️  Breeder ${i} creation failed"
           done
           
           # List all breeders to verify
@@ -588,7 +672,7 @@ jobs:
           # Create multiple credentials in succession  
           echo "🔨 Creating multiple credentials..."
           for i in {1..3}; do
-            cat > /tmp/credential-stress-config-${i}.yaml << EOF
+            cat > credential-stress-config-${i}.yaml << EOF
           name: "stress-test-cred-${i}"
           credentialType: "ssh_private_key"
           description: "Stress test credential ${i}"
@@ -600,9 +684,10 @@ jobs:
           EOF
           
             docker run --rm --network host \
-              -v /tmp/credential-stress-config-${i}.yaml:/credential-config.yaml:ro \
+              -v $(pwd):/work \
+              -w /work \
               "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-              credential create --file=/credential-config.yaml || echo "⚠️  Credential ${i} creation failed"
+              credential create --file=credential-stress-config-${i}.yaml || echo "⚠️  Credential ${i} creation failed"
           done
           
           # List all credentials to verify

--- a/.github/workflows/charts--smoke-tests.yaml
+++ b/.github/workflows/charts--smoke-tests.yaml
@@ -229,6 +229,9 @@ jobs:
           # Fetch config from upstream godon repository to unique filename
           curl -s https://raw.githubusercontent.com/godon-dev/godon/refs/heads/master/examples/network.yml -o network-upstream.yml
 
+          # Fix file permissions so container can read it
+          chmod 644 network-upstream.yml
+
           echo "📝 DEBUG: Verifying fetched config file:"
           cat network-upstream.yml
           echo "File exists in workflow: $(ls -la network-upstream.yml)"
@@ -236,6 +239,8 @@ jobs:
           CREATE_OUTPUT=$(docker run --rm --network host \
             -v $(pwd):/work:ro \
             -w /work \
+            -e SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt \
+            -e NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt \
             "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
             breeder create --name="smoke-test-breeder" --file=network-upstream.yml 2>&1 || true)
 

--- a/.github/workflows/charts--smoke-tests.yaml
+++ b/.github/workflows/charts--smoke-tests.yaml
@@ -226,16 +226,18 @@ jobs:
           # Test 2: Create a new breeder
           echo "🔨 BREEDER CREATE - Creating test breeder:"
 
-          # Use same config as API CI - fetch from upstream godon repository
-          curl -s https://raw.githubusercontent.com/godon-dev/godon/main/examples/network.yml -o /tmp/breeder-test-config.yaml
+          # Fetch config from upstream godon repository to unique filename
+          curl -s https://raw.githubusercontent.com/godon-dev/godon/refs/heads/master/examples/network.yml -o network-upstream.yml
 
           echo "📝 DEBUG: Verifying fetched config file:"
-          cat /tmp/breeder-test-config.yaml
+          cat network-upstream.yml
+          echo "File exists in workflow: $(ls -la network-upstream.yml)"
 
           CREATE_OUTPUT=$(docker run --rm --network host \
-            -v /tmp/breeder-test-config.yaml:/breeder-config.yaml:ro \
+            -v $(pwd):/work:ro \
+            -w /work \
             "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-            breeder create --name="smoke-test-breeder" --file=/breeder-config.yaml 2>&1 || true)
+            breeder create --name="smoke-test-breeder" --file=network-upstream.yml 2>&1 || true)
 
           echo "Create output: ${CREATE_OUTPUT}"
 

--- a/.github/workflows/charts--smoke-tests.yaml
+++ b/.github/workflows/charts--smoke-tests.yaml
@@ -242,7 +242,7 @@ jobs:
             -e SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt \
             -e NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt \
             "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-            breeder create --name="smoke-test-breeder" --file=network-upstream.yml 2>&1 || true)
+            breeder create --name="smoke-test-breeder" --file=network-upstream.yml --output=json 2>&1 || true)
 
           echo "Create output: ${CREATE_OUTPUT}"
 
@@ -427,7 +427,7 @@ jobs:
           CREATE_OUTPUT=$(docker run --rm --network host \
             -v /tmp/credential-test-config.yaml:/credential-config.yaml:ro \
             "${CLI_CONTAINER_IMAGE}" --hostname=${API_HOST} --port=${API_PORT} --insecure \
-            credential create --file=/credential-config.yaml 2>&1)
+            credential create --file=/credential-config.yaml --output=json 2>&1)
           
           echo "${CREATE_OUTPUT}"
           
@@ -627,7 +627,7 @@ jobs:
             --hostname=${API_HOST} --port=${API_PORT} --insecure breeder list 2>/dev/null || echo "[]")
           
           # Extract UUIDs of test breeders (those containing "stress-test" or "smoke-test")
-          echo "${BREEDER_OUTPUT}" | jq -r '.[]? | select(.name | contains("stress-test") or contains("smoke-test")) | .uuid' 2>/dev/null | while read UUID; do
+          echo "${BREEDER_OUTPUT}" | jq -r '.[]? | select(.name | contains("stress-test") or contains("smoke-test")) | .id' 2>/dev/null | while read UUID; do
             if [ -n "${UUID}" ]; then
               echo "Deleting breeder: ${UUID}"
               docker run --rm --network host "${CLI_CONTAINER_IMAGE}" \

--- a/.github/workflows/charts--smoke-tests.yaml
+++ b/.github/workflows/charts--smoke-tests.yaml
@@ -226,42 +226,10 @@ jobs:
           # Test 2: Create a new breeder
           echo "🔨 BREEDER CREATE - Creating test breeder:"
 
-          # Create test breeder config - matching CI test format
-          cat > /tmp/breeder-test-config.yaml << 'EOF'
-          breeder:
-            type: linux_performance
+          # Use same config as API CI - fetch from upstream godon repository
+          curl -s https://raw.githubusercontent.com/godon-dev/godon/main/examples/network.yml -o /tmp/breeder-test-config.yaml
 
-          run:
-            parallel: 1
-            completion_criteria:
-              iterations:
-                min: 10
-                max: 100
-
-          effectuation:
-            targets:
-              - type: ssh
-                address: test.local
-                connection:
-                  username: test_user
-                  private_key: /path/to/key
-
-          cooperation:
-            active: false
-
-          objectives:
-            - name: test_metric
-              direction: minimize
-
-          settings:
-            sysctl:
-              vm_swappiness:
-                constraints:
-                  upper: 100
-                  lower: 0
-          EOF
-
-          echo "📝 DEBUG: Verifying created config file:"
+          echo "📝 DEBUG: Verifying fetched config file:"
           cat /tmp/breeder-test-config.yaml
 
           CREATE_OUTPUT=$(docker run --rm --network host \

--- a/.github/workflows/charts--smoke-tests.yaml
+++ b/.github/workflows/charts--smoke-tests.yaml
@@ -649,9 +649,31 @@ jobs:
             cat > breeder-stress-config-${i}.yaml << EOF
           meta:
             configVersion: "0.2"
+          breeder:
+            type: "linux_performance"
           settings:
-            test: "value_${i}"
-            iteration: ${i}
+            sysctl:
+              vm.swappiness:
+                step: 1
+                constraints:
+                  lower: 1
+                  upper: 100
+          objectives:
+            - name: "test_metric_${i}"
+              direction: minimize
+              reconnaissance:
+                service: prometheus
+                query: "scalar(test_metric_${i})"
+                stabilization_seconds: 1
+                samples: 1
+                interval: 1
+          effectuation:
+            targets:
+              - type: "ssh"
+                id: "test_target_${i}"
+                address: "10.0.5.${i}"
+                username: "test_user"
+                credentialName: "test_credential_${i}"
           EOF
 
             docker run --rm --network host \

--- a/charts/godon/Chart.yaml
+++ b/charts/godon/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm Chart for godon optimizer stack
 name: godon
-version: 0.2.5
+version: 0.2.6
 appVersion: 0.0.6
 home: https://github.com/cherusk/godon-charts/godon
 maintainers:

--- a/charts/godon/Chart.yaml
+++ b/charts/godon/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm Chart for godon optimizer stack
 name: godon
-version: 0.2.6
+version: 0.2.7
 appVersion: 0.0.6
 home: https://github.com/cherusk/godon-charts/godon
 maintainers:

--- a/charts/godon/osuosl_deploy_values.yml
+++ b/charts/godon/osuosl_deploy_values.yml
@@ -38,7 +38,7 @@ windmill:
 api:
   image:
     repository: "ghcr.io/godon-dev/godon-api"
-    tag: "0.0.14"
+    tag: "0.0.15"
   env:
   - name: WINDMILL_BASE_URL
     value: "http://windmill-app.godon.svc.cluster.local:8000/api"

--- a/charts/godon/osuosl_deploy_values.yml
+++ b/charts/godon/osuosl_deploy_values.yml
@@ -8,7 +8,7 @@ godon_seeder:
     tag: "0.0.18"
   env:
   - name: CONTROLLER_VERSION
-    value: "0.12.0"
+    value: "0.13.0"
   - name: BREEDER_VERSION
     value: "0.7.0"
   - name: WINDMILL_BASE_URL

--- a/charts/godon/osuosl_deploy_values.yml
+++ b/charts/godon/osuosl_deploy_values.yml
@@ -8,7 +8,7 @@ godon_seeder:
     tag: "0.0.18"
   env:
   - name: CONTROLLER_VERSION
-    value: "0.9.0"
+    value: "0.10.0"
   - name: BREEDER_VERSION
     value: "0.7.0"
   - name: WINDMILL_BASE_URL

--- a/charts/godon/osuosl_deploy_values.yml
+++ b/charts/godon/osuosl_deploy_values.yml
@@ -8,7 +8,7 @@ godon_seeder:
     tag: "0.0.18"
   env:
   - name: CONTROLLER_VERSION
-    value: "0.14.0"
+    value: "0.15.0"
   - name: BREEDER_VERSION
     value: "0.7.0"
   - name: WINDMILL_BASE_URL

--- a/charts/godon/osuosl_deploy_values.yml
+++ b/charts/godon/osuosl_deploy_values.yml
@@ -8,7 +8,7 @@ godon_seeder:
     tag: "0.0.18"
   env:
   - name: CONTROLLER_VERSION
-    value: "0.10.0"
+    value: "0.11.0"
   - name: BREEDER_VERSION
     value: "0.7.0"
   - name: WINDMILL_BASE_URL

--- a/charts/godon/osuosl_deploy_values.yml
+++ b/charts/godon/osuosl_deploy_values.yml
@@ -8,7 +8,7 @@ godon_seeder:
     tag: "0.0.18"
   env:
   - name: CONTROLLER_VERSION
-    value: "0.13.0"
+    value: "0.14.0"
   - name: BREEDER_VERSION
     value: "0.7.0"
   - name: WINDMILL_BASE_URL

--- a/charts/godon/osuosl_deploy_values.yml
+++ b/charts/godon/osuosl_deploy_values.yml
@@ -38,7 +38,7 @@ windmill:
 api:
   image:
     repository: "ghcr.io/godon-dev/godon-api"
-    tag: "0.0.15"
+    tag: "0.0.16"
   env:
   - name: WINDMILL_BASE_URL
     value: "http://windmill-app.godon.svc.cluster.local:8000/api"

--- a/charts/godon/osuosl_deploy_values.yml
+++ b/charts/godon/osuosl_deploy_values.yml
@@ -8,7 +8,7 @@ godon_seeder:
     tag: "0.0.18"
   env:
   - name: CONTROLLER_VERSION
-    value: "0.11.0"
+    value: "0.12.0"
   - name: BREEDER_VERSION
     value: "0.7.0"
   - name: WINDMILL_BASE_URL
@@ -38,7 +38,7 @@ windmill:
 api:
   image:
     repository: "ghcr.io/godon-dev/godon-api"
-    tag: "0.0.13"
+    tag: "0.0.14"
   env:
   - name: WINDMILL_BASE_URL
     value: "http://windmill-app.godon.svc.cluster.local:8000/api"

--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -38,7 +38,7 @@ godon_seeder:
   - name: WINDMILL_BASE_URL
     value: "http://windmill-app.godon.svc.cluster.local:8000/api"
   - name: CONTROLLER_VERSION
-    value: "0.14.0"
+    value: "0.15.0"
   - name: BREEDER_VERSION
     value: "0.7.0"
 

--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -38,7 +38,7 @@ godon_seeder:
   - name: WINDMILL_BASE_URL
     value: "http://windmill-app.godon.svc.cluster.local:8000/api"
   - name: CONTROLLER_VERSION
-    value: "0.13.0"
+    value: "0.14.0"
   - name: BREEDER_VERSION
     value: "0.7.0"
 

--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -108,7 +108,7 @@ metrics_exporter:
 api:
   image:
     repository: "ghcr.io/godon-dev/godon-api"
-    tag: "0.0.14"
+    tag: "0.0.15"
     pullPolicy: IfNotPresent
     pullSecret: ""
 

--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -38,7 +38,7 @@ godon_seeder:
   - name: WINDMILL_BASE_URL
     value: "http://windmill-app.godon.svc.cluster.local:8000/api"
   - name: CONTROLLER_VERSION
-    value: "0.12.0"
+    value: "0.13.0"
   - name: BREEDER_VERSION
     value: "0.7.0"
 

--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -38,7 +38,7 @@ godon_seeder:
   - name: WINDMILL_BASE_URL
     value: "http://windmill-app.godon.svc.cluster.local:8000/api"
   - name: CONTROLLER_VERSION
-    value: "0.9.0"
+    value: "0.10.0"
   - name: BREEDER_VERSION
     value: "0.7.0"
 

--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -38,7 +38,7 @@ godon_seeder:
   - name: WINDMILL_BASE_URL
     value: "http://windmill-app.godon.svc.cluster.local:8000/api"
   - name: CONTROLLER_VERSION
-    value: "0.10.0"
+    value: "0.11.0"
   - name: BREEDER_VERSION
     value: "0.7.0"
 

--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -38,7 +38,7 @@ godon_seeder:
   - name: WINDMILL_BASE_URL
     value: "http://windmill-app.godon.svc.cluster.local:8000/api"
   - name: CONTROLLER_VERSION
-    value: "0.11.0"
+    value: "0.12.0"
   - name: BREEDER_VERSION
     value: "0.7.0"
 
@@ -108,7 +108,7 @@ metrics_exporter:
 api:
   image:
     repository: "ghcr.io/godon-dev/godon-api"
-    tag: "0.0.13"
+    tag: "0.0.14"
     pullPolicy: IfNotPresent
     pullSecret: ""
 

--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -108,7 +108,7 @@ metrics_exporter:
 api:
   image:
     repository: "ghcr.io/godon-dev/godon-api"
-    tag: "0.0.15"
+    tag: "0.0.16"
     pullPolicy: IfNotPresent
     pullSecret: ""
 


### PR DESCRIPTION
  Replace hand-crafted breeder config with network.yml from upstream
  godon repository to match what API CI uses. This avoids CLI YAML-to-JSON
  conversion bugs that were causing "Invalid JSON in request body" errors.