### PR TITLE
make git tag authoritative for chart version

### DIFF
--- a/.github/workflows/charts--lint.yaml
+++ b/.github/workflows/charts--lint.yaml
@@ -46,7 +46,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           echo "🔍 Running comprehensive chart linting..."
-          ct lint --target-branch ${{ github.event.repository.default_branch }}
+          ct lint --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=false
           echo "✅ Chart linting passed"
 
       - name: Run helm template validation

--- a/.github/workflows/charts--release.yaml
+++ b/.github/workflows/charts--release.yaml
@@ -4,6 +4,11 @@ on:
   release:
     types: [created]
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Chart version to publish (e.g., 0.2.10)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -26,26 +31,20 @@ jobs:
       - name: Get chart version
         id: chart-version
         run: |
-          # Read version from Chart.yaml (source of truth)
-          CHART_VERSION=$(grep "^version:" charts/godon/Chart.yaml | awk '{print $2}')
-          echo "version=${CHART_VERSION}" >> $GITHUB_OUTPUT
-          echo "Chart version: ${CHART_VERSION}"
-
-      - name: Validate tag matches chart version
-        if: github.event_name == 'release'
-        run: |
-          CHART_VERSION="${{ steps.chart-version.outputs.version }}"
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-
-          if [ "$CHART_VERSION" != "$TAG_VERSION" ]; then
-            echo "❌ Error: Chart version (${CHART_VERSION}) doesn't match git tag (${TAG_VERSION})"
-            echo "Please either:"
-            echo "  1. Update Chart.yaml to version ${TAG_VERSION}"
-            echo "  2. Or create a tag matching version ${CHART_VERSION}"
-            exit 1
+          # Git tag is always source of truth
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG_VERSION="${{ github.event.inputs.version }}"
+          else
+            TAG_VERSION="${GITHUB_REF#refs/tags/v}"
           fi
+          echo "version=${TAG_VERSION}" >> $GITHUB_OUTPUT
+          echo "Tag version: ${TAG_VERSION}"
 
-          echo "✅ Chart version and tag match: ${CHART_VERSION}"
+      - name: Update Chart.yaml to match tag
+        run: |
+          TAG_VERSION="${{ steps.chart-version.outputs.version }}"
+          sed -i "s/^version:.*/version: ${TAG_VERSION}/" charts/godon/Chart.yaml
+          echo "✅ Updated Chart.yaml to version ${TAG_VERSION}"
 
       - name: Package chart
         run: |
@@ -63,6 +62,7 @@ jobs:
           helm push godon-${CHART_VERSION}.tgz oci://ghcr.io/godon-dev/charts
 
       - name: Attach chart to GitHub Release
+        if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1
         with:
           files: godon-*.tgz

--- a/README.md
+++ b/README.md
@@ -15,38 +15,33 @@ helm install godon godon/godon
 
 ## How to Release
 
-**Chart version is the source of truth.** The git tag MUST match the chart version.
+**Git tag is the source of truth.** The chart version is automatically updated to match the tag.
 
-1. **Update chart version** in `charts/godon/Chart.yaml`:
-   ```yaml
-   version: 0.2.11  # Bump this
-   appVersion: 0.0.7  # Bump if app changed
-   ```
-
-2. **Commit and push**:
+1. **Commit any chart changes** (don't worry about version):
    ```bash
-   git add charts/godon/Chart.yaml
-   git commit -m "Bump chart to 0.2.11"
+   # Make your changes...
+   git add charts/
+   git commit -m "Update chart"
    git push
    ```
 
-3. **Create matching git tag**:
+2. **Create git tag** (this sets the version):
    ```bash
-   git tag v0.2.11  # Must match Chart.yaml version!
+   git tag v0.2.11
    git push origin v0.2.11
    ```
 
-4. **Create GitHub Release**:
+3. **Create GitHub Release**:
    ```bash
    gh release create v0.2.11
    # Or via GitHub UI
    ```
 
-5. **Workflow automatically**:
-   - ✅ Validates tag matches chart version
+4. **Workflow automatically**:
+   - ✅ Updates Chart.yaml to match tag
    - ✅ Publishes to OCI: `oci://ghcr.io/godon-dev/charts/godon`
    - ✅ Publishes to GitHub Pages: `https://godon-dev.github.io/godon-charts/charts`
    - ✅ Updates `index.yaml`
    - ✅ Attaches chart `.tgz` to release
 
-**If tag doesn't match chart version**, the workflow will fail with a clear error message.
+**Note:** Chart version in Chart.yaml will be overwritten by the tag version during release.


### PR DESCRIPTION
- Workflow updates Chart.yaml to match git tag during release
- Revert validation since tag is now source of truth
- Add workflow_dispatch with version input for manual releases
- Disable ct version increment check in lint workflow
- Update README to reflect new process