### PR TITLE
Bump versions and configure Windmill full image

### DIFF
--- a/charts/godon/Chart.yaml
+++ b/charts/godon/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm Chart for godon optimizer stack
 name: godon
-version: 0.2.11
+version: 0.2.12
 appVersion: 0.0.6
 home: https://github.com/cherusk/godon-charts/godon
 maintainers:
@@ -23,7 +23,7 @@ keywords:
   - cooperative-metaheuristics
 dependencies:
   - name: windmill
-    version: 4.0.23
+    version: 4.0.61
     repository: https://windmill-labs.github.io/windmill-helm-charts
     alias: windmill
   - name: postgresql

--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -23,7 +23,7 @@ godon_seeder:
   enabled: true
   image:
     repository: ghcr.io/godon-dev/godon-seeder
-    tag: 0.0.19
+    tag: 0.0.20
     pullPolicy: IfNotPresent
     pullSecret: ""
   resources:
@@ -40,13 +40,14 @@ godon_seeder:
   - name: CONTROLLER_VERSION
     value: "0.28.0"
   - name: BREEDER_VERSION
-    value: "0.23.0"
+    value: "0.26.0"
 
 ########################################
 ## Component | Windmill Workflow Orchestration Engine
 ########################################
 windmill:
   windmill:
+    image: "ghcr.io/windmill-labs/windmill-full"
     appReplicas: 1
     lspReplicas: 1
     workerGroups:


### PR DESCRIPTION
- Godon chart: 0.2.11 → 0.2.12
- Windmill chart: 4.0.23 → 4.0.61 (latest)
- Windmill image: set to ghcr.io/windmill-labs/windmill-full globally
- godon-seeder: 0.0.19 → 0.0.20
- BREEDER_VERSION: 0.23.0 → 0.26.0
- CONTROLLER_VERSION: keep at 0.28.0