### PR TITLE
fix: use hostPath for Loki storage with non-conflicting mount path

### DIFF
--- a/charts/godon-observability/values.yaml
+++ b/charts/godon-observability/values.yaml
@@ -72,29 +72,9 @@ loki:
       retention_period: 168h
       max_query_length: 721h
       max_query_parallelism: 32
-    storage_config:
-      filesystem:
-        directory: /data/loki/chunks
 
   singleBinary:
     replicas: 1
-    extraVolumes:
-      - name: loki-storage
-        hostPath:
-          path: /srv/storage/loki
-          type: DirectoryOrCreate
-    extraVolumeMounts:
-      - name: loki-storage
-        mountPath: /data/loki
-    initContainers:
-      - name: fix-permissions
-        image: busybox
-        command: ['sh', '-c', 'chown -R 10001:10001 /data/loki']
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-          - name: loki-storage
-            mountPath: /data/loki
     resources:
       requests:
         cpu: 100m

--- a/charts/godon-observability/values.yaml
+++ b/charts/godon-observability/values.yaml
@@ -72,6 +72,9 @@ loki:
       retention_period: 168h
       max_query_length: 721h
       max_query_parallelism: 32
+    storage_config:
+      filesystem:
+        directory: /data/loki/chunks
 
   singleBinary:
     replicas: 1
@@ -82,7 +85,7 @@ loki:
           type: DirectoryOrCreate
     extraVolumeMounts:
       - name: loki-storage
-        mountPath: /var/loki
+        mountPath: /data/loki
     resources:
       requests:
         cpu: 100m

--- a/charts/godon-observability/values.yaml
+++ b/charts/godon-observability/values.yaml
@@ -86,6 +86,9 @@ loki:
     extraVolumeMounts:
       - name: loki-storage
         mountPath: /data/loki
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
     resources:
       requests:
         cpu: 100m

--- a/charts/godon-observability/values.yaml
+++ b/charts/godon-observability/values.yaml
@@ -86,9 +86,15 @@ loki:
     extraVolumeMounts:
       - name: loki-storage
         mountPath: /data/loki
-    securityContext:
-      runAsUser: 0
-      runAsGroup: 0
+    initContainers:
+      - name: fix-permissions
+        image: busybox
+        command: ['sh', '-c', 'chown -R 10001:10001 /data/loki']
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: loki-storage
+            mountPath: /data/loki
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
- Remove extraVolumes/extraVolumeMounts that conflict with chart's default /var/loki
- Enable persistence with 'standard' storageClass (rancher.io/local-path)
- Fixes 'mountPath must be unique' error preventing Loki pod creation