### PR TITLE
fix metrics-exporter: bind 0.0.0.0, correct targetPort, fix pushgatew…

### DIFF
--- a/charts/godon-observability/values.yaml
+++ b/charts/godon-observability/values.yaml
@@ -57,12 +57,6 @@ prometheus:
       enabled: false
 
   extraScrapeConfigs: |
-    - job_name: 'godon-pushgateway'
-      honor_labels: true
-      scrape_interval: 5s
-      static_configs:
-        - targets:
-          - 'godon-pushgateway.godon.svc.cluster.local:9091'
     - job_name: 'godon-metrics-exporter'
       scrape_interval: 5s
       static_configs:

--- a/charts/godon/templates/metrics-exporter/metrics-exporter-deployment.yaml
+++ b/charts/godon/templates/metrics-exporter/metrics-exporter-deployment.yaml
@@ -18,7 +18,6 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      ## multiple metrics exporters can run concurrently
       maxSurge: 25%
       maxUnavailable: 0
   selector:
@@ -44,6 +43,11 @@ spec:
       containers:
         - name:  godon-metrics-exporter
           {{- include "metrics_exporter.image" . | indent 10 }}
+          args:
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - {{ .Values.metrics_exporter.containerPort | quote }}
           resources:
             {{- toYaml .Values.metrics_exporter.resources | nindent 12 }}
           env:

--- a/charts/godon/templates/metrics-exporter/service.yaml
+++ b/charts/godon/templates/metrics-exporter/service.yaml
@@ -19,7 +19,7 @@ spec:
     - protocol: TCP
       name: "metrics-port"
       port: {{ .Values.metrics_exporter.port }}
-      targetPort: {{ .Values.metrics_exporter.port }}
+      targetPort: {{ .Values.metrics_exporter.containerPort }}
   selector:
     component: metrics-exporter
     release: {{ .Release.Name }}

--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -143,6 +143,7 @@ metrics_exporter:
   replicas: 1
 
   port: 9099
+  containerPort: 8089
 
   resources:
     requests:
@@ -348,7 +349,7 @@ archive-db:
       - name: YSQL_DB
         value: archive_db
       - name: PUSH_GATEWAY_URL
-        value: "http://godon-pushgateway:9091"
+        value: "http://godon-prometheus-pushgateway:9091"
       - name: PUSH_METRICS_ENABLED
         value: "true"
 

--- a/stacks/osuosl/test-stack.yaml
+++ b/stacks/osuosl/test-stack.yaml
@@ -85,6 +85,10 @@ archive-db:
 ########################################
 metrics_exporter:
   env:
+  - name: PUSH_GATEWAY_URL
+    value: "http://godon-prometheus-pushgateway:9091"
+  - name: PUSH_METRICS_ENABLED
+    value: "true"
   - name: ARCHIVE_DB_HOST
     value: "yb-tservers.godon.svc.cluster.local:5433"
   - name: ARCHIVE_DB_USER


### PR DESCRIPTION
…ay URL

- deployment: pass --host 0.0.0.0 --port via args
- service: use containerPort for targetPort
- values: add containerPort 8089, fix PUSH_GATEWAY_URL service name
- test-stack: preserve PUSH_GATEWAY_URL env in override
- observability: scrape metrics-exporter instead of pushgateway