### PR TITLE
fix: use correct Bitnami key 'extendedConfiguration' instead of 'exte…

### DIFF
--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -329,10 +329,6 @@ mcp:
 ## Component | Postgres Database Storing Godon Components Meta Data
 ########################################
 metadata-db:
-  image:
-    repository: "postgres"
-    tag: 13
-    pullPolicy: IfNotPresent
   auth:
     username: meta_data
     password: meta_data
@@ -369,10 +365,6 @@ metadata-db:
 ## Component | Postgres Database for Windmill
 ########################################
 windmill-db:
-  image:
-    repository: "postgres"
-    tag: 14
-    pullPolicy: IfNotPresent
   auth:
     username: windmill
     password: windmill

--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -52,7 +52,7 @@ windmill:
     image: "ghcr.io/windmill-labs/windmill-full"
     appReplicas: 1
     lspReplicas: 1
-    databaseUrl: "postgres://windmill:windmill@windmill-db-primary:5432/windmill?sslmode=disable"
+    databaseUrl: "postgres://windmill:windmill@godon-windmill-db:5432/windmill?sslmode=disable"
     workerGroups:
       # Controller workers - handle fast operations (preflight, breeder_create, etc)
       # Timeout hierarchy: Script-level > Worker group DEFAULT_TIMEOUT_SECONDS > Global default
@@ -351,19 +351,19 @@ metadata-db:
         memory: "1Gi"
     initdb:
       args: "-E UTF8"
-    extendedConf:
-      max_connections: "500"
-      shared_buffers: "128MB"
-      effective_cache_size: "512MB"
-      maintenance_work_mem: "64MB"
-      checkpoint_completion_target: "0.9"
-      wal_buffers: "16MB"
-      default_statistics_target: "100"
-      random_page_cost: "1.1"
-      effective_io_concurrency: "200"
-      work_mem: "2096kB"
-      min_wal_size: "1GB"
-      max_wal_size: "4GB"
+    extendedConfiguration: |
+      max_connections = 500
+      shared_buffers = 128MB
+      effective_cache_size = 512MB
+      maintenance_work_mem = 64MB
+      checkpoint_completion_target = 0.9
+      wal_buffers = 16MB
+      default_statistics_target = 100
+      random_page_cost = 1.1
+      effective_io_concurrency = 200
+      work_mem = 2096kB
+      min_wal_size = 1GB
+      max_wal_size = 4GB
 
 ########################################
 ## Component | Postgres Database for Windmill
@@ -388,10 +388,10 @@ windmill-db:
         memory: "1Gi"
     initdb:
       args: "-E UTF8"
-    extendedConf:
-      max_connections: "500"
-      shared_buffers: "128MB"
-      effective_cache_size: "512MB"
+    extendedConfiguration: |
+      max_connections = 500
+      shared_buffers = 128MB
+      effective_cache_size = 512MB
 
 ########################################
 ## Component | Knowledge Archive Database for Cooperating Config Breeders


### PR DESCRIPTION
…ndedConf'

The Bitnami postgresql chart expects primary.extendedConfiguration as a multiline string, not primary.extendedConf as a YAML dict. The old key was silently ignored, meaning PG tuning was never applied.