### PR TITLE
fix: use official postgres image with command override for PG tuning

### DIFF
--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -329,61 +329,47 @@ mcp:
 ## Component | Postgres Database Storing Godon Components Meta Data
 ########################################
 metadata-db:
+  image:
+    repository: "postgres"
+    tag: 16
+    pullPolicy: IfNotPresent
   auth:
     username: meta_data
     password: meta_data
     database: meta_data
 
-  # Increase resources for 10 concurrent workers (3 controller + 5 breeder + 2 default)
-  # Increase max_connections for worker pool (default: 100)
-  # Each worker opens multiple connections for job processing
   primary:
-    resources:
-      requests:
-        cpu: "200m"
-        memory: "256Mi"
-      limits:
-        cpu: "1000m"
-        memory: "1Gi"
-    initdb:
-      args: "-E UTF8"
-    extendedConfiguration: |
-      max_connections = 500
-      shared_buffers = 128MB
-      effective_cache_size = 512MB
-      maintenance_work_mem = 64MB
-      checkpoint_completion_target = 0.9
-      wal_buffers = 16MB
-      default_statistics_target = 100
-      random_page_cost = 1.1
-      effective_io_concurrency = 200
-      work_mem = 2096kB
-      min_wal_size = 1GB
-      max_wal_size = 4GB
+    command:
+      - "postgres"
+      - "-c"
+      - "max_connections=500"
+      - "-c"
+      - "shared_buffers=128MB"
+      - "-c"
+      - "effective_cache_size=512MB"
 
 ########################################
 ## Component | Postgres Database for Windmill
 ########################################
 windmill-db:
+  image:
+    repository: "postgres"
+    tag: 16
+    pullPolicy: IfNotPresent
   auth:
     username: windmill
     password: windmill
     database: windmill
 
   primary:
-    resources:
-      requests:
-        cpu: "200m"
-        memory: "256Mi"
-      limits:
-        cpu: "1000m"
-        memory: "1Gi"
-    initdb:
-      args: "-E UTF8"
-    extendedConfiguration: |
-      max_connections = 500
-      shared_buffers = 128MB
-      effective_cache_size = 512MB
+    command:
+      - "postgres"
+      - "-c"
+      - "max_connections=500"
+      - "-c"
+      - "shared_buffers=128MB"
+      - "-c"
+      - "effective_cache_size=512MB"
 
 ########################################
 ## Component | Knowledge Archive Database for Cooperating Config Breeders


### PR DESCRIPTION
Bitnami postgresql image tags are no longer available on Docker Hub. Use official postgres:16 image with primary.command to pass -c flags directly to the postgres binary. This bypasses the Bitnami entrypoint config loading entirely.