### PR TITLE
fix: set uid/fsGroup to 999 for official postgres image

### DIFF
--- a/charts/godon/values.yaml
+++ b/charts/godon/values.yaml
@@ -340,6 +340,10 @@ metadata-db:
     database: meta_data
 
   primary:
+    containerSecurityContext:
+      runAsUser: 999
+    podSecurityContext:
+      fsGroup: 999
     args:
       - "-c"
       - "max_connections=500"
@@ -361,6 +365,10 @@ windmill-db:
     database: windmill
 
   primary:
+    containerSecurityContext:
+      runAsUser: 999
+    podSecurityContext:
+      fsGroup: 999
     args:
       - "-c"
       - "max_connections=500"


### PR DESCRIPTION
Bitnami chart defaults to uid 1001 but official postgres image expects uid 999. Without this, initdb fails with permission denied on /var/lib/postgresql/data.